### PR TITLE
Add Student Inactivity Email Notification

### DIFF
--- a/crm/templates/mail/reminder_for_inactive_students.html
+++ b/crm/templates/mail/reminder_for_inactive_students.html
@@ -1,0 +1,21 @@
+{% extends "mail_templated/base.tpl" %}
+
+{% load absolute_url %}
+
+{% block subject %}
+Hello, {{ c.customer_first_name | capfirst }}! We've missed you at ELK Academy.
+{% endblock %}
+
+{% block body %}
+Dear {{ c.customer_first_name | capfirst }},
+
+We hope you're doing well! We noticed you haven't scheduled or attended a lesson in the past week. Learning is a continuous journey, and we encourage you to stay on track.
+
+Jump back in and plan your next lesson in the dashboard at {% absolute_url "home" %}#schedule.
+
+We're here to support you every step of the way!
+
+Best wishes,
+ELK Academy
+Education + Love = Knowledge
+{% endblock %}

--- a/elk/settings.py
+++ b/elk/settings.py
@@ -321,6 +321,10 @@ CELERYBEAT_SCHEDULE = {
         'task': 'accounting.tasks.bill_timeline_entries',
         'schedule': timedelta(minutes=1),
     },
+    'check_student_inactivity': {
+        'task': 'market.tasks.check_student_inactivity_and_send_emails',
+        'schedule': timedelta(days=1),
+    },
 }
 
 

--- a/market/tasks.py
+++ b/market/tasks.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta, timezone
+
+from django.db.models import Exists, OuterRef
+from elk.logging import logger
+from crm.models import Customer
+from elk.celery import app as celery
+from mailer.owl import Owl
+from market.models import Class, Subscription
+
+
+@celery.task
+def check_student_inactivity_and_send_emails():
+    """Checks for student inactivity and sends notifications to those who haven't had classes in over a week."""
+    now = datetime.now(timezone.utc)
+    one_week_ago = now - timedelta(days=7)
+
+    lazy_customers = Customer.objects.annotate(
+        is_subscribed=Exists(
+            Subscription.objects.filter(
+                customer=OuterRef('id'),
+                is_fully_used=False)
+        ),
+        active_student=Exists(
+            Class.objects.filter(
+                customer=OuterRef('id'),
+                subscription__isnull=False,
+                timeline__end__range=(one_week_ago, now)
+            )
+        )
+    ).filter(
+        is_subscribed=True,
+        active_student=False
+    )
+
+    for user in lazy_customers:
+        try:
+            send_inactivity_email_to_student(user)
+        except Exception as e:
+            logger.error(f"Error sending inactivity email to student {user.id}: {e}")
+
+
+def send_inactivity_email_to_student(customer):
+    """This function sends an inactivity warning email to the student using Owl."""
+    owl = Owl(
+        template='mail/reminder_for_inactive_students.html',
+        ctx={'c': customer},
+        to=[customer.user.email],
+        timezone=customer.user.crm.timezone,
+    )
+    owl.send()


### PR DESCRIPTION
This pull request introduces a feature to monitor student inactivity and send out email reminders.

Celery Task Addition: Implemented a task (check_student_inactivity_and_send_emails) that runs periodically to identify students who haven't been active for over a week.

Recommendations for Improvement:

To enhance user experience and prevent potential annoyance from frequent reminders, it's advisable to stagger the email notifications. Instead of sending reminders daily, we can adopt a schedule like:

Day 1: First Reminder
Day 3: Second Reminder
Day 7: Third Reminder
... and so on.
This can be achieved by:

Database Extension: Introduce new tables/models to keep track of reminder history for each user, recording the timestamp of each reminder.

Reminder Logic Refinement: Adjust the logic in our Celery task to not just check for inactivity, but also to reference the reminder history table to determine if and when a user should receive the next reminder.

Business Alignment: Discuss this proposed strategy with stakeholders to ensure it aligns with our communication goals and brand identity.
